### PR TITLE
Add slew rate limiter for drivetrain

### DIFF
--- a/src/main/include/subsystems/Drivetrain.hpp
+++ b/src/main/include/subsystems/Drivetrain.hpp
@@ -7,7 +7,9 @@
 
 #include <Eigen/Core>
 #include <frc/ADXRS450_Gyro.h>
+#include <frc/BuiltInAccelerometer.h>
 #include <frc/Encoder.h>
+#include <frc/SlewRateLimiter.h>
 #include <frc/SpeedControllerGroup.h>
 #include <frc/drive/DifferentialDrive.h>
 #include <frc/geometry/Pose2d.h>


### PR DESCRIPTION
Adds a slew rate limiter for the drivetrain, so the robot cannot tip over due to an unexpected and sudden stop.