### PR TITLE
Remove wpilib container from format job for faster checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,6 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # This grabs the WPILib docker container
-    container: wpilib/roborio-cross-ubuntu:2020-18.04
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Install add-apt-repository
@@ -41,6 +38,9 @@ jobs:
       run: |
         chmod +x .github/workflows/clang-format.sh
         sudo ./.github/workflows/clang-format.sh 10
+
+    - name: Install setuptools
+      run: sudo apt-get install python3-setuptools -y
 
     - name: Install wpiformat
       run: sudo pip3 install wpiformat


### PR DESCRIPTION
Time is saved by not having to download the docker image and set it up.