### PR TITLE
Fix turret controller limits

### DIFF
--- a/src/main/cpp/subsystems/Turret.cpp
+++ b/src/main/cpp/subsystems/Turret.cpp
@@ -66,7 +66,7 @@ void Turret::ControllerPeriodic() {
     m_controller.SetMeasuredOutputs(GetAngle());
 
     m_controller.SetDrivetrainStatus(m_drivetrain.GetNextXhat());
-    m_controller.SetHardLimitOutputs(HasPassedCWLimit(), HasPassedCWLimit());
+    m_controller.SetHardLimitOutputs(HasPassedCCWLimit(), HasPassedCWLimit());
     m_controller.Update(now - m_lastTime, now - GetStartTime());
 
     auto globalMeasurement = m_vision.GetGlobalMeasurement();


### PR DESCRIPTION
The turret wasn't stopping at the counterclockwise soft limit with
automatic control. This was caused by using the clockwise soft limit for
both sides.

Fixes #80.