### PR TITLE
Create low-level unit tests

### DIFF
--- a/src/main/cpp/subsystems/Drivetrain.cpp
+++ b/src/main/cpp/subsystems/Drivetrain.cpp
@@ -172,6 +172,10 @@ Eigen::Matrix<double, 7, 1> Drivetrain::GetStates() const {
     return m_controller->GetStates();
 }
 
+Eigen::Matrix<double, 2, 1> Drivetrain::GetInputs() const {
+    return m_controller->GetInputs();
+}
+
 units::ampere_t Drivetrain::GetCurrentDraw() const {
     return m_drivetrainSim.GetCurrentDraw();
 }

--- a/src/main/include/subsystems/Climber.hpp
+++ b/src/main/include/subsystems/Climber.hpp
@@ -1,11 +1,14 @@
-// Copyright (c) 2020 FRC Team 3512. All Rights Reserved.
+// Copyright (c) 2020-2021 FRC Team 3512. All Rights Reserved.
 
 #pragma once
 
 #include <frc/Solenoid.h>
+#include <frc/simulation/LinearSystemSim.h>
+#include <frc/system/plant/LinearSystemId.h>
 #include <networktables/NetworkTableEntry.h>
 #include <networktables/NetworkTableInstance.h>
 #include <units/length.h>
+#include <units/voltage.h>
 
 #include "Constants.hpp"
 #include "rev/CANEncoder.hpp"
@@ -35,6 +38,21 @@ public:
      */
     units::meter_t GetElevatorPosition();
 
+    /**
+     * Returns true if encoder has passed top limit.
+     */
+    bool HasPassedTopLimit();
+
+    /**
+     * Returns true if encoder has passed bottom limit.
+     */
+    bool HasPassedBottomLimit();
+
+    /**
+     * Returns the voltage applied to elevator motor.
+     */
+    units::volt_t GetElevatorMotorOutput() const;
+
     void RobotPeriodic() override;
 
     void TeleopPeriodic() override;
@@ -57,6 +75,11 @@ private:
     nt::NetworkTableInstance m_inst = nt::NetworkTableInstance::GetDefault();
     nt::NetworkTableEntry m_elevatorEncoderEntry =
         m_inst.GetEntry("/Diagnostics/Climber/Elevator encoder");
+
+    // Simulation variables
+    frc::sim::LinearSystemSim<2, 1, 1> m_elevatorSim{
+        frc::LinearSystemId::ElevatorSystem(frc::DCMotor::NEO(), 4.5_kg,
+                                            0.86_in, 20.0)};
 
     /**
      * Sets the traverser speed.

--- a/src/main/include/subsystems/Drivetrain.hpp
+++ b/src/main/include/subsystems/Drivetrain.hpp
@@ -176,6 +176,11 @@ public:
     Eigen::Matrix<double, 7, 1> GetStates() const;
 
     /**
+     * Returns the drivetrain inputs.
+     */
+    Eigen::Matrix<double, 2, 1> GetInputs() const;
+
+    /**
      * Returns current drawn in simulation.
      */
     units::ampere_t GetCurrentDraw() const;

--- a/src/test/cpp/ClimberTest.cpp
+++ b/src/test/cpp/ClimberTest.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2020-2021 FRC Team 3512. All Rights Reserved.
+
+#include <frc/Notifier.h>
+#include <frc/simulation/JoystickSim.h>
+#include <frc/simulation/SimHooks.h>
+#include <frc2/Timer.h>
+#include <gtest/gtest.h>
+
+#include "Constants.hpp"
+#include "SimulatorTest.hpp"
+#include "subsystems/Climber.hpp"
+#include "subsystems/Drivetrain.hpp"
+#include "subsystems/Flywheel.hpp"
+#include "subsystems/Turret.hpp"
+#include "subsystems/Vision.hpp"
+
+class ClimberTest : public frc3512::SimulatorTest {};
+
+TEST_F(ClimberTest, ConfigSpaceLimits) {
+    frc2::Timer timer;
+    timer.Start();
+
+    frc::sim::JoystickSim appendageStick1{
+        frc3512::Constants::Robot::kAppendageStick1Port};
+
+    frc3512::Vision vision;
+    frc3512::Drivetrain drivetrain;
+    frc3512::Flywheel flywheel{drivetrain};
+    frc3512::Turret turret{vision, drivetrain, flywheel};
+    frc3512::Climber climber{turret};
+
+    // Make sure turret doesn't interfere with climber movement
+    turret.Reset(units::radian_t{wpi::math::pi / 2.0});
+
+    frc3512::SubsystemBase::RunAllTeleopInit();
+    frc::Notifier controllerPeriodic{[&] {
+        climber.RobotPeriodic();
+        climber.TeleopPeriodic();
+    }};
+    controllerPeriodic.StartPeriodic(frc3512::Constants::kDt);
+
+    // Verify climber can't move below bottom soft limit
+    appendageStick1.SetRawButton(1, true);
+    appendageStick1.SetY(1.0);
+    frc::sim::StepTiming(20_ms);
+    EXPECT_EQ(climber.GetElevatorMotorOutput(), 0_V);
+
+    frc::sim::StepTiming(2_s);
+
+    // Move climber into top limit
+    while (!climber.HasPassedTopLimit()) {
+        appendageStick1.SetRawButton(1, true);
+        appendageStick1.SetY(-1.0);
+        frc::sim::StepTiming(20_ms);
+
+        ASSERT_LT(timer.Get(), 30_s)
+            << "Climber took too long to reach top limit";
+    }
+
+    // Don't let climber move past top limit
+    appendageStick1.SetRawButton(1, true);
+    appendageStick1.SetY(-1.0);
+    frc::sim::StepTiming(20_ms);
+    EXPECT_EQ(climber.GetElevatorMotorOutput(), 0_V);
+
+    frc3512::SubsystemBase::RunAllDisabledInit();
+}

--- a/src/test/cpp/IntakeTest.cpp
+++ b/src/test/cpp/IntakeTest.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2021 FRC Team 3512. All Rights Reserved.
+
+#include <frc/Notifier.h>
+#include <frc/simulation/SimHooks.h>
+#include <gtest/gtest.h>
+
+#include "SimulatorTest.hpp"
+#include "subsystems/Drivetrain.hpp"
+#include "subsystems/Flywheel.hpp"
+#include "subsystems/Intake.hpp"
+
+class IntakeTest : public frc3512::SimulatorTest {};
+
+TEST_F(IntakeTest, DeployTest) {
+    frc3512::Drivetrain drivetrain;
+    frc3512::Flywheel flywheel{drivetrain};
+    frc3512::Intake intake{flywheel};
+
+    frc3512::SubsystemBase::RunAllTeleopInit();
+    frc::Notifier controllerPeriodic{[&] { intake.TeleopPeriodic(); }};
+    controllerPeriodic.StartPeriodic(frc3512::Constants::kDt);
+
+    intake.Deploy();
+
+    frc::sim::StepTiming(2_s);
+
+    EXPECT_TRUE(intake.IsDeployed());
+
+    frc::sim::StepTiming(2_s);
+
+    intake.Stow();
+
+    frc3512::SubsystemBase::RunAllDisabledInit();
+
+    EXPECT_FALSE(intake.IsDeployed());
+}

--- a/src/test/cpp/ModeTest.cpp
+++ b/src/test/cpp/ModeTest.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2020-2021 FRC Team 3512. All Rights Reserved.
+
+#include <frc/Notifier.h>
+#include <frc/simulation/SimHooks.h>
+#include <gtest/gtest.h>
+
+#include "Constants.hpp"
+#include "SimulatorTest.hpp"
+#include "subsystems/Drivetrain.hpp"
+
+class ModeTest : public frc3512::SimulatorTest {};
+
+TEST_F(ModeTest, AutonToTeleopTest) {
+    frc3512::Drivetrain drivetrain;
+
+    frc3512::SubsystemBase::RunAllAutonomousInit();
+    frc::Notifier autonomousPeriodic{[&] { drivetrain.ControllerPeriodic(); }};
+    autonomousPeriodic.StartPeriodic(frc3512::Constants::kDt);
+
+    const frc::Pose2d kInitialPose{5_m, 0_m, 0_rad};
+    drivetrain.Reset(kInitialPose);
+    drivetrain.AddTrajectory(kInitialPose, {}, frc::Pose2d{15_m, 0_m, 0_rad});
+
+    frc::sim::StepTiming(3_s);
+
+    EXPECT_GT(drivetrain.GetInputs()(0), 0.0);
+    EXPECT_GT(drivetrain.GetInputs()(1), 0.0);
+
+    autonomousPeriodic.Stop();
+
+    frc3512::SubsystemBase::RunAllTeleopInit();
+    frc::Notifier teleopPeriodic{[&] {
+        drivetrain.TeleopPeriodic();
+        drivetrain.ControllerPeriodic();
+    }};
+    teleopPeriodic.StartPeriodic(frc3512::Constants::kDt);
+
+    frc::sim::StepTiming(20_ms);
+
+    EXPECT_EQ(drivetrain.GetInputs()(0), 0.0);
+    EXPECT_EQ(drivetrain.GetInputs()(1), 0.0);
+
+    frc3512::SubsystemBase::RunAllDisabledInit();
+}


### PR DESCRIPTION
Implements unit tests for testing basic functionality of the climber (WIP) and intake. Also, a test is written in which it ensures
that reset functions are correctly working when transitioning between modes.

Fixes #99