### PR TITLE
Remove unnecessary use of quintic spline

### DIFF
--- a/src/main/cpp/autonomous/AutoTargetZoneShootSix.cpp
+++ b/src/main/cpp/autonomous/AutoTargetZoneShootSix.cpp
@@ -96,7 +96,7 @@ void Robot::AutoTargetZoneShootSixPeriodic() {
             auto config = Drivetrain::MakeTrajectoryConfig();
             config.SetReversed(true);
 
-            m_drivetrain.SetWaypoints({endPose, midPose}, config);
+            m_drivetrain.SetWaypoints(endPose, {}, midPose, config);
             state = State::kTrenchShoot;
             break;
         }


### PR DESCRIPTION
The test plots don't show any difference between the cubic and quintic
spline here, so we can use cubic splines because they're quicker to
compute.