### PR TITLE
Replace autonomous mode state machines with actor model

### DIFF
--- a/src/main/cpp/AutonomousChooser.cpp
+++ b/src/main/cpp/AutonomousChooser.cpp
@@ -10,14 +10,13 @@
 namespace frc3512 {
 
 AutonomousChooser::AutonomousChooser(wpi::StringRef name,
-                                     std::function<void()> initFunc,
-                                     std::function<void()> periodicFunc) {
+                                     std::function<void()> func) {
     m_defaultChoice = name;
-    m_choices[name] = {initFunc, periodicFunc};
+    m_choices[name] = func;
     m_names.emplace_back(name);
 
     m_selectedChoice = name;
-    m_selectedAuton = m_choices[name];
+    m_selectedAuton = &m_choices[name];
 
     frc::SmartDashboard::PutData("Autonomous modes", this);
 
@@ -39,32 +38,19 @@ AutonomousChooser::AutonomousChooser(wpi::StringRef name,
 }
 
 AutonomousChooser::~AutonomousChooser() {
+    EndAutonomous();
     m_selectedEntry.RemoveListener(m_selectedListenerHandle);
 }
 
 void AutonomousChooser::AddAutonomous(wpi::StringRef name,
-                                      std::function<void()> initFunc,
-                                      std::function<void()> periodicFunc) {
-    m_choices[name] = {initFunc, periodicFunc};
+                                      std::function<void()> func) {
+    m_choices[name] = func;
     m_names.emplace_back(name);
 
     // Unlike std::map, wpi::StringMap elements are not sorted
     std::sort(m_names.begin(), m_names.end());
 
     m_optionsEntry.SetStringArray(m_names);
-}
-
-void AutonomousChooser::RunAutonomousInit() {
-    {
-        std::scoped_lock lock{m_mutex};
-        fmt::print("{} autonomous\n", m_selectedChoice);
-        m_selectedAuton = m_choices[m_selectedChoice];
-    }
-    std::get<0>(m_selectedAuton)();
-}
-
-void AutonomousChooser::RunAutonomousPeriodic() {
-    std::get<1>(m_selectedAuton)();
 }
 
 void AutonomousChooser::SelectAutonomous(wpi::StringRef name) {
@@ -77,6 +63,55 @@ void AutonomousChooser::SelectAutonomous(wpi::StringRef name) {
 
 const std::vector<std::string>& AutonomousChooser::GetAutonomousNames() const {
     return m_names;
+}
+
+void AutonomousChooser::Yield() {
+    m_awaitingAuton = false;
+    m_cond.notify_one();
+    m_cond.wait(m_autonLock, [&] { return m_awaitingAuton; });
+}
+
+void AutonomousChooser::Return() {
+    m_awaitingAuton = false;
+    m_cond.notify_one();
+}
+
+void AutonomousChooser::AwaitStartAutonomous() {
+    {
+        std::scoped_lock lock{m_mutex};
+        fmt::print("{} autonomous\n", m_selectedChoice);
+        m_selectedAuton = &m_choices[m_selectedChoice];
+    }
+
+    m_awaitingAuton = true;
+    m_autonThread = std::thread{[=] {
+        m_autonLock.lock();
+        m_autonRunning = true;
+        (*m_selectedAuton)();
+        m_autonRunning = false;
+        Return();
+        m_autonLock.unlock();
+    }};
+    m_cond.wait(m_mainLock, [&] { return !m_awaitingAuton; });
+}
+
+void AutonomousChooser::AwaitRunAutonomous() {
+    if (m_autonRunning) {
+        m_awaitingAuton = true;
+        m_cond.notify_one();
+        m_cond.wait(m_mainLock, [&] { return !m_awaitingAuton; });
+    }
+}
+
+void AutonomousChooser::EndAutonomous() {
+    if (m_autonRunning) {
+        m_awaitingAuton = true;
+        m_cond.notify_one();
+        m_cond.wait(m_mainLock, [&] { return !m_awaitingAuton; });
+    }
+    if (m_autonThread.joinable()) {
+        m_autonThread.join();
+    }
 }
 
 void AutonomousChooser::InitSendable(frc::SendableBuilder& builder) {

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -14,36 +14,24 @@
 namespace frc3512 {
 
 Robot::Robot() {
-    m_autonChooser.AddAutonomous(
-        "Left Side Intake", [=] { AutoLeftSideIntakeInit(); },
-        [=] { AutoLeftSideIntakePeriodic(); });
-    m_autonChooser.AddAutonomous(
-        "Loading Zone Drive Forward",
-        [=] { AutoLoadingZoneDriveForwardInit(); },
-        [=] { AutoLoadingZoneDriveForwardPeriodic(); });
-    m_autonChooser.AddAutonomous(
-        "Loading Zone Shoot Three Balls",
-        [=] { AutoLoadingZoneShootThreeInit(); },
-        [=] { AutoLoadingZoneShootThreePeriodic(); });
-    m_autonChooser.AddAutonomous(
-        "Target Zone Shoot Three Balls",
-        [=] { AutoTargetZoneShootThreeInit(); },
-        [=] { AutoTargetZoneShootThreePeriodic(); });
-    m_autonChooser.AddAutonomous(
-        "Target Zone Shoot Six Balls", [=] { AutoTargetZoneShootSixInit(); },
-        [=] { AutoTargetZoneShootSixPeriodic(); });
-    m_autonChooser.AddAutonomous(
-        "Right Side Drive Forward", [=] { AutoRightSideDriveForwardInit(); },
-        [=] { AutoRightSideDriveForwardPeriodic(); });
-    m_autonChooser.AddAutonomous(
-        "Right Side Shoot Three Balls", [=] { AutoRightSideShootThreeInit(); },
-        [=] { AutoRightSideShootThreePeriodic(); });
-    m_autonChooser.AddAutonomous(
-        "Right Side Shoot Six Balls", [=] { AutoRightSideShootSixInit(); },
-        [=] { AutoRightSideShootSixPeriodic(); });
-    m_autonChooser.AddAutonomous(
-        "Right Side Intake", [=] { AutoRightSideIntakeInit(); },
-        [=] { AutoRightSideIntakePeriodic(); });
+    m_autonChooser.AddAutonomous("Left Side Intake",
+                                 [=] { AutoLeftSideIntake(); });
+    m_autonChooser.AddAutonomous("Loading Zone Drive Forward",
+                                 [=] { AutoLoadingZoneDriveForward(); });
+    m_autonChooser.AddAutonomous("Loading Zone Shoot Three Balls",
+                                 [=] { AutoLoadingZoneShootThree(); });
+    m_autonChooser.AddAutonomous("Target Zone Shoot Three Balls",
+                                 [=] { AutoTargetZoneShootThree(); });
+    m_autonChooser.AddAutonomous("Target Zone Shoot Six Balls",
+                                 [=] { AutoTargetZoneShootSix(); });
+    m_autonChooser.AddAutonomous("Right Side Drive Forward",
+                                 [=] { AutoRightSideDriveForward(); });
+    m_autonChooser.AddAutonomous("Right Side Shoot Three Balls",
+                                 [=] { AutoRightSideShootThree(); });
+    m_autonChooser.AddAutonomous("Right Side Shoot Six Balls",
+                                 [=] { AutoRightSideShootSix(); });
+    m_autonChooser.AddAutonomous("Right Side Intake",
+                                 [=] { AutoRightSideIntake(); });
 
     frc::LiveWindow::GetInstance()->DisableAllTelemetry();
 
@@ -63,6 +51,7 @@ bool Robot::IsShooting() const { return m_state != ShootingState::kIdle; }
 void Robot::SimulationInit() { SubsystemBase::RunAllSimulationInit(); }
 
 void Robot::DisabledInit() {
+    m_autonChooser.EndAutonomous();
     SubsystemBase::RunAllDisabledInit();
 
     // Reset teleop shooting state machine when disabling robot
@@ -74,12 +63,18 @@ void Robot::DisabledInit() {
 
 void Robot::AutonomousInit() {
     SubsystemBase::RunAllAutonomousInit();
-    m_autonChooser.RunAutonomousInit();
+    m_autonChooser.AwaitStartAutonomous();
 }
 
-void Robot::TeleopInit() { SubsystemBase::RunAllTeleopInit(); }
+void Robot::TeleopInit() {
+    m_autonChooser.EndAutonomous();
+    SubsystemBase::RunAllTeleopInit();
+}
 
-void Robot::TestInit() { SubsystemBase::RunAllTestInit(); }
+void Robot::TestInit() {
+    m_autonChooser.EndAutonomous();
+    SubsystemBase::RunAllTestInit();
+}
 
 void Robot::RobotPeriodic() {
     SubsystemBase::RunAllRobotPeriodic();
@@ -100,7 +95,7 @@ void Robot::DisabledPeriodic() { SubsystemBase::RunAllDisabledPeriodic(); }
 
 void Robot::AutonomousPeriodic() {
     SubsystemBase::RunAllAutonomousPeriodic();
-    m_autonChooser.RunAutonomousPeriodic();
+    m_autonChooser.AwaitRunAutonomous();
 
     RunShooterSM();
 }

--- a/src/main/cpp/autonomous/AutoLoadingZoneDriveForward.cpp
+++ b/src/main/cpp/autonomous/AutoLoadingZoneDriveForward.cpp
@@ -7,43 +7,22 @@
 
 namespace frc3512 {
 
-namespace {
-enum class State { kInit, kIdle };
-}  // namespace
+void Robot::AutoLoadingZoneDriveForward() {
+    // Initial Pose - Right in line with the Loading Zone
+    const frc::Pose2d initialPose{12.89_m, 5.662_m,
+                                  units::radian_t{wpi::math::pi}};
+    // End Pose - Drive forward slightly
+    const frc::Pose2d endPose{12.89_m - 1.5 * Drivetrain::kLength, 5.662_m,
+                              units::radian_t{wpi::math::pi}};
 
-static State state;
-static frc2::Timer autonTimer;
-
-// Initial Pose - Right in line with the Loading Zone
-static const frc::Pose2d initialPose{12.89_m, 5.662_m,
-                                     units::radian_t{wpi::math::pi}};
-// End Pose - Drive forward slightly
-static const frc::Pose2d endPose{12.89_m - 1.5 * Drivetrain::kLength, 5.662_m,
-                                 units::radian_t{wpi::math::pi}};
-
-void Robot::AutoLoadingZoneDriveForwardInit() {
     m_drivetrain.Reset(initialPose);
+    m_drivetrain.SetWaypoints(initialPose, {}, endPose);
 
-    state = State::kInit;
-    autonTimer.Reset();
-    autonTimer.Start();
-}
-
-void Robot::AutoLoadingZoneDriveForwardPeriodic() {
-    switch (state) {
-        case State::kInit: {
-            m_drivetrain.SetWaypoints(initialPose, {}, endPose);
-            state = State::kIdle;
-            break;
-        }
-        case State::kIdle: {
-            break;
-        }
-    }
-
-    if constexpr (IsSimulation()) {
-        if (autonTimer.HasElapsed(14.97_s)) {
-            EXPECT_EQ(State::kIdle, state);
+    while (!m_drivetrain.AtGoal()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
         }
     }
 }

--- a/src/main/cpp/autonomous/AutoLoadingZoneShootThree.cpp
+++ b/src/main/cpp/autonomous/AutoLoadingZoneShootThree.cpp
@@ -7,51 +7,33 @@
 
 namespace frc3512 {
 
-namespace {
-enum class State { kDriveAwayFromGoal, kShoot, kIdle };
-}  // namespace
+void Robot::AutoLoadingZoneShootThree() {
+    // Initial Pose - Right in line with the Loading Zone
+    const frc::Pose2d initialPose{12.89_m, 5.662_m,
+                                  units::radian_t{wpi::math::pi}};
+    // End Pose - Drive forward slightly
+    const frc::Pose2d endPose{12.89_m - 1.5 * Drivetrain::kLength, 5.662_m,
+                              units::radian_t{wpi::math::pi}};
 
-static State state;
-static frc2::Timer autonTimer;
-
-// Initial Pose - Right in line with the Loading Zone
-static const frc::Pose2d initialPose{12.89_m, 5.662_m,
-                                     units::radian_t{wpi::math::pi}};
-// End Pose - Drive forward slightly
-static const frc::Pose2d endPose{12.89_m - 1.5 * Drivetrain::kLength, 5.662_m,
-                                 units::radian_t{wpi::math::pi}};
-
-void Robot::AutoLoadingZoneShootThreeInit() {
     m_drivetrain.Reset(initialPose);
+    m_drivetrain.SetWaypoints(initialPose, {}, endPose);
 
-    state = State::kDriveAwayFromGoal;
-    autonTimer.Reset();
-    autonTimer.Start();
-}
-
-void Robot::AutoLoadingZoneShootThreePeriodic() {
-    switch (state) {
-        case State::kDriveAwayFromGoal: {
-            m_drivetrain.SetWaypoints(initialPose, {}, endPose);
-            state = State::kShoot;
-            break;
-        }
-        case State::kShoot: {
-            // Shoot 3x
-            if (m_drivetrain.AtGoal()) {
-                Shoot();
-                state = State::kIdle;
-            }
-            break;
-        }
-        case State::kIdle: {
-            break;
+    while (!m_drivetrain.AtGoal()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
         }
     }
 
-    if constexpr (IsSimulation()) {
-        if (autonTimer.HasElapsed(14.97_s)) {
-            EXPECT_EQ(State::kIdle, state);
+    // Shoot 3x
+    Shoot();
+
+    while (IsShooting()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
         }
     }
 }

--- a/src/main/cpp/autonomous/AutoNoOp.cpp
+++ b/src/main/cpp/autonomous/AutoNoOp.cpp
@@ -4,11 +4,9 @@
 
 namespace frc3512 {
 
-void Robot::AutoNoOpInit() {
+void Robot::AutoNoOp() {
     m_turret.SetControlMode(TurretController::ControlMode::kManual);
-}
 
-void Robot::AutoNoOpPeriodic() {
     if constexpr (IsSimulation()) {
         EXPECT_EQ(0_V, m_turret.GetMotorOutput());
     }

--- a/src/main/cpp/autonomous/AutoRightSideDriveForward.cpp
+++ b/src/main/cpp/autonomous/AutoRightSideDriveForward.cpp
@@ -7,43 +7,22 @@
 
 namespace frc3512 {
 
-namespace {
-enum class State { kInit, kIdle };
-}  // namespace
+void Robot::AutoRightSideDriveForward() {
+    // Initial Pose - Right in line with the three balls in the Trench Run
+    const frc::Pose2d initialPose{12.89_m, 0.71_m,
+                                  units::radian_t{wpi::math::pi}};
+    // End Pose - Drive forward slightly
+    const frc::Pose2d endPose{12.89_m - 1.5 * Drivetrain::kLength, 0.71_m,
+                              units::radian_t{wpi::math::pi}};
 
-static State state;
-static frc2::Timer autonTimer;
-
-// Initial Pose - Right in line with the three balls in the Trench Run
-static const frc::Pose2d initialPose{12.89_m, 0.71_m,
-                                     units::radian_t{wpi::math::pi}};
-// End Pose - Drive forward slightly
-static const frc::Pose2d endPose{12.89_m - 1.5 * Drivetrain::kLength, 0.71_m,
-                                 units::radian_t{wpi::math::pi}};
-
-void Robot::AutoRightSideDriveForwardInit() {
     m_drivetrain.Reset(initialPose);
+    m_drivetrain.SetWaypoints(initialPose, {}, endPose);
 
-    state = State::kInit;
-    autonTimer.Reset();
-    autonTimer.Start();
-}
-
-void Robot::AutoRightSideDriveForwardPeriodic() {
-    switch (state) {
-        case State::kInit: {
-            m_drivetrain.SetWaypoints(initialPose, {}, endPose);
-            state = State::kIdle;
-            break;
-        }
-        case State::kIdle: {
-            break;
-        }
-    }
-
-    if constexpr (IsSimulation()) {
-        if (autonTimer.HasElapsed(14.97_s)) {
-            EXPECT_EQ(State::kIdle, state);
+    while (!m_drivetrain.AtGoal()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
         }
     }
 }

--- a/src/main/cpp/autonomous/AutoRightSideIntake.cpp
+++ b/src/main/cpp/autonomous/AutoRightSideIntake.cpp
@@ -8,78 +8,44 @@
 
 namespace frc3512 {
 
-namespace {
-enum class State { kInit, kTrenchRun, kIdle };
-}  // namespace
+void Robot::AutoRightSideIntake() {
+    // Initial Pose - Right in line with the three balls in the Trench Run
+    const frc::Pose2d initialPose{12.89_m, 0.71_m,
+                                  units::radian_t{wpi::math::pi}};
+    // End Pose - Second ball in the Trench Run
+    const frc::Pose2d endPose{8.906_m, 0.71_m, units::radian_t{wpi::math::pi}};
 
-static State state;
-static State lastState;
-static frc2::Timer autonTimer;
-
-// Initial Pose - Right in line with the three balls in the Trench Run
-static const frc::Pose2d initialPose{12.89_m, 0.71_m,
-                                     units::radian_t{wpi::math::pi}};
-// End Pose - Second ball in the Trench Run
-static const frc::Pose2d endPose{8.906_m, 0.71_m,
-                                 units::radian_t{wpi::math::pi}};
-
-void Robot::AutoRightSideIntakeInit() {
     m_drivetrain.Reset(initialPose);
 
-    state = State::kInit;
-    lastState = State::kInit;
-    autonTimer.Reset();
-    autonTimer.Start();
-}
+    // Add a constraint to slow down the drivetrain while it's
+    // approaching the balls
+    frc::RectangularRegionConstraint regionConstraint{
+        frc::Translation2d{endPose.X(),
+                           endPose.Y() - 0.5 * Drivetrain::kLength},
+        // X: First/Closest ball in the trench run
+        frc::Translation2d{9.82_m + 0.5 * Drivetrain::kLength,
+                           initialPose.Y() + 0.5 * Drivetrain::kLength},
+        frc::MaxVelocityConstraint{1_mps}};
 
-void Robot::AutoRightSideIntakePeriodic() {
-    switch (state) {
-        case State::kInit: {
-            m_intake.Deploy();
-            state = State::kTrenchRun;
-            break;
-        }
-        case State::kTrenchRun: {
-            // Add a constraint to slow down the drivetrain while it's
-            // approaching the balls
-            static frc::RectangularRegionConstraint regionConstraint{
-                frc::Translation2d{endPose.X(),
-                                   endPose.Y() - 0.5 * Drivetrain::kLength},
-                // X: First/Closest ball in the trench run
-                frc::Translation2d{9.82_m + 0.5 * Drivetrain::kLength,
-                                   initialPose.Y() + 0.5 * Drivetrain::kLength},
-                frc::MaxVelocityConstraint{1_mps}};
+    auto config = Drivetrain::MakeTrajectoryConfig();
+    config.AddConstraint(regionConstraint);
+    m_drivetrain.SetWaypoints(initialPose, {}, endPose, config);
 
-            if (lastState != state) {
-                auto config = Drivetrain::MakeTrajectoryConfig();
-                config.AddConstraint(regionConstraint);
-                m_drivetrain.SetWaypoints(initialPose, {}, endPose, config);
+    // Intake Balls x2
+    m_intake.Deploy();
+    m_intake.SetArmMotor(Intake::ArmMotorDirection::kIntake);
+    m_intake.SetFunnel(0.4);
 
-                lastState = state;
-            }
-
-            // Intake Balls x2
-            m_intake.SetArmMotor(Intake::ArmMotorDirection::kIntake);
-            m_intake.SetFunnel(0.4);
-
-            if (m_drivetrain.AtGoal()) {
-                m_intake.SetArmMotor(Intake::ArmMotorDirection::kIdle);
-                m_intake.SetFunnel(0);
-
-                state = State::kIdle;
-            }
-            break;
-        }
-        case State::kIdle: {
-            break;
+    while (!m_drivetrain.AtGoal()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
         }
     }
 
-    if constexpr (IsSimulation()) {
-        if (autonTimer.HasElapsed(14.97_s)) {
-            EXPECT_EQ(State::kIdle, state);
-        }
-    }
+    m_intake.SetArmMotor(Intake::ArmMotorDirection::kIdle);
+    m_intake.SetFunnel(0);
 }
 
 }  // namespace frc3512

--- a/src/main/cpp/autonomous/AutoRightSideShootSix.cpp
+++ b/src/main/cpp/autonomous/AutoRightSideShootSix.cpp
@@ -8,118 +8,96 @@
 
 namespace frc3512 {
 
-namespace {
-enum class State {
-    kInit,
-    kShoot,
-    kDoneShooting,
-    kTrenchRun,
-    kDriveBack,
-    kTrenchShoot,
-    kIdle
-};
-}  // namespace
+void Robot::AutoRightSideShootSix() {
+    // Initial Pose - Right in line with the three balls in the Trench Run
+    const frc::Pose2d initialPose{12.89_m, 0.71_m,
+                                  units::radian_t{wpi::math::pi}};
+    // Mid Pose - Drive forward slightly
+    const frc::Pose2d midPose{12.89_m - 1.5 * Drivetrain::kLength, 0.71_m,
+                              units::radian_t{wpi::math::pi}};
+    // End Pose - Third/Farthest ball in the Trench Run
+    const frc::Pose2d endPose{8_m, 0.71_m, units::radian_t{wpi::math::pi}};
 
-static State state;
-static State lastState;
-static frc2::Timer autonTimer;
-
-// Initial Pose - Right in line with the three balls in the Trench Run
-static const frc::Pose2d initialPose{12.89_m, 0.71_m,
-                                     units::radian_t{wpi::math::pi}};
-// Mid Pose - Drive forward slightly
-static const frc::Pose2d midPose{12.89_m - 1.5 * Drivetrain::kLength, 0.71_m,
-                                 units::radian_t{wpi::math::pi}};
-// End Pose - Third/Farthest ball in the Trench Run
-static const frc::Pose2d endPose{8_m, 0.71_m, units::radian_t{wpi::math::pi}};
-
-void Robot::AutoRightSideShootSixInit() {
     m_drivetrain.Reset(initialPose);
 
-    state = State::kInit;
-    lastState = State::kInit;
-    autonTimer.Reset();
-    autonTimer.Start();
-}
+    // Move back to shoot three comfortably
+    m_drivetrain.SetWaypoints(initialPose, {}, midPose);
 
-void Robot::AutoRightSideShootSixPeriodic() {
-    switch (state) {
-        case State::kInit: {
-            m_intake.Deploy();
-            // Move back to shoot three comfortably
-            m_drivetrain.SetWaypoints(initialPose, {}, midPose);
-            state = State::kShoot;
-            break;
-        }
-        case State::kShoot: {
-            // Shoot x3
-            if (m_drivetrain.AtGoal()) {
-                Shoot();
-                state = State::kDoneShooting;
-            }
-            break;
-        }
-        case State::kDoneShooting: {
-            if (!IsShooting()) {
-                state = State::kTrenchRun;
-            }
-            break;
-        }
-        case State::kTrenchRun: {
-            // Add a constraint to slow down the drivetrain while it's
-            // approaching the balls
-            static frc::RectangularRegionConstraint regionConstraint{
-                frc::Translation2d{endPose.X(),
-                                   endPose.Y() - 0.5 * Drivetrain::kLength},
-                // X: First/Closest ball in the trench run
-                frc::Translation2d{9.82_m + 0.5 * Drivetrain::kLength,
-                                   initialPose.Y() + 0.5 * Drivetrain::kLength},
-                frc::MaxVelocityConstraint{1.6_mps}};
+    m_intake.Deploy();
 
-            if (lastState != state) {
-                auto config = Drivetrain::MakeTrajectoryConfig();
-                config.AddConstraint(regionConstraint);
-                m_drivetrain.SetWaypoints(midPose, {}, endPose, config);
-
-                lastState = state;
-            }
-
-            // Intake Balls x3
-            m_intake.SetArmMotor(Intake::ArmMotorDirection::kIntake);
-            m_intake.SetFunnel(0.4);
-
-            if (m_drivetrain.AtGoal()) {
-                state = State::kDriveBack;
-            }
-            break;
-        }
-        case State::kDriveBack: {
-            m_intake.SetArmMotor(Intake::ArmMotorDirection::kIdle);
-            m_intake.SetFunnel(0.0);
-
-            auto config = Drivetrain::MakeTrajectoryConfig();
-            config.SetReversed(true);
-
-            m_drivetrain.SetWaypoints({endPose, midPose}, config);
-            state = State::kTrenchShoot;
-            break;
-        }
-        case State::kTrenchShoot: {
-            // Shoot x3
-            if (m_drivetrain.AtGoal()) {
-                Shoot();
-                state = State::kIdle;
-            }
-            break;
-        }
-        case State::kIdle: {
-            break;
+    while (!m_drivetrain.AtGoal()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
         }
     }
 
-    if constexpr (IsSimulation()) {
-        if (autonTimer.HasElapsed(14.97_s)) {
-            EXPECT_EQ(State::kIdle, state);
+    // Shoot x3
+    Shoot();
+
+    while (IsShooting()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
+        }
+    }
+
+    // Add a constraint to slow down the drivetrain while it's
+    // approaching the balls
+    frc::RectangularRegionConstraint regionConstraint{
+        frc::Translation2d{endPose.X(),
+                           endPose.Y() - 0.5 * Drivetrain::kLength},
+        // X: First/Closest ball in the trench run
+        frc::Translation2d{9.82_m + 0.5 * Drivetrain::kLength,
+                           initialPose.Y() + 0.5 * Drivetrain::kLength},
+        frc::MaxVelocityConstraint{1.6_mps}};
+
+    {
+        auto config = Drivetrain::MakeTrajectoryConfig();
+        config.AddConstraint(regionConstraint);
+        m_drivetrain.SetWaypoints(midPose, {}, endPose, config);
+    }
+
+    // Intake Balls x3
+    m_intake.SetArmMotor(Intake::ArmMotorDirection::kIntake);
+    m_intake.SetFunnel(0.4);
+
+    while (!m_drivetrain.AtGoal()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
+        }
+    }
+
+    m_intake.SetArmMotor(Intake::ArmMotorDirection::kIdle);
+    m_intake.SetFunnel(0.0);
+
+    // Drive back
+    {
+        auto config = Drivetrain::MakeTrajectoryConfig();
+        config.SetReversed(true);
+        m_drivetrain.SetWaypoints({endPose, midPose}, config);
+    }
+
+    while (!m_drivetrain.AtGoal()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
+        }
+    }
+
+    // Shoot x3
+    Shoot();
+
+    while (IsShooting()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
         }
     }
 }

--- a/src/main/cpp/autonomous/AutoTargetZoneShootSix.cpp
+++ b/src/main/cpp/autonomous/AutoTargetZoneShootSix.cpp
@@ -8,115 +8,88 @@
 
 namespace frc3512 {
 
-namespace {
-enum class State {
-    kInit,
-    kDoneShooting,
-    kTrenchRun,
-    kDriveBack,
-    kTrenchShoot,
-    kIdle
-};
-}  // namespace
+void Robot::AutoTargetZoneShootSix() {
+    // Initial Pose - Right in line with the Target Zone
+    const frc::Pose2d initialPose{12.89_m, 2.41_m,
+                                  units::radian_t{wpi::math::pi}};
+    // Mid Pose - Right before first/closest ball in the Trench Run
+    const frc::Pose2d midPose{9.82_m + 0.5 * Drivetrain::kLength, 0.705_m,
+                              units::radian_t{wpi::math::pi}};
+    // End Pose - Third/Farthest ball in the Trench Run
+    const frc::Pose2d endPose{8_m, 0.71_m, units::radian_t{wpi::math::pi}};
 
-static State state;
-static State lastState;
-static frc2::Timer autonTimer;
-
-// Initial Pose - Right in line with the Target Zone
-static const frc::Pose2d initialPose{12.89_m, 2.41_m,
-                                     units::radian_t{wpi::math::pi}};
-// Mid Pose - Right before first/closest ball in the Trench Run
-static const frc::Pose2d midPose{9.82_m + 0.5 * Drivetrain::kLength, 0.705_m,
-                                 units::radian_t{wpi::math::pi}};
-// End Pose - Third/Farthest ball in the Trench Run
-static const frc::Pose2d endPose{8_m, 0.71_m, units::radian_t{wpi::math::pi}};
-
-void Robot::AutoTargetZoneShootSixInit() {
     m_drivetrain.Reset(initialPose);
 
-    state = State::kInit;
-    lastState = State::kInit;
-    autonTimer.Reset();
-    autonTimer.Start();
-}
+    m_intake.Deploy();
 
-void Robot::AutoTargetZoneShootSixPeriodic() {
-    switch (state) {
-        case State::kInit: {
-            m_intake.Deploy();
-            // Shoot x3
-            Shoot();
-            state = State::kDoneShooting;
-            break;
-        }
-        case State::kDoneShooting: {
-            if (!IsShooting()) {
-                state = State::kTrenchRun;
-            }
-            break;
-        }
-        case State::kTrenchRun: {
-            static frc::RectangularRegionConstraint regionConstraint{
-                // X: Leftmost ball on trench run
-                frc::Translation2d{endPose.X(),
-                                   0.71_m - 0.5 * Drivetrain::kLength},
-                // X: Rightmost ball on trench run
-                frc::Translation2d{9.82_m + 0.5 * Drivetrain::kLength,
-                                   0.71_m + 0.5 * Drivetrain::kLength},
-                frc::MaxVelocityConstraint{1.6_mps}};
+    // Shoot x3
+    Shoot();
 
-            if (lastState != state) {
-                // Add a constraint to slow down the drivetrain while it's
-                // approaching the balls
-                auto config = Drivetrain::MakeTrajectoryConfig();
-
-                config.AddConstraint(regionConstraint);
-                // Interior Translation: First/Closest ball in trench run
-
-                m_drivetrain.SetWaypoints({initialPose, midPose, endPose},
-                                          config);
-
-                lastState = state;
-            }
-
-            // Intake Balls x3
-            m_intake.SetArmMotor(Intake::ArmMotorDirection::kIntake);
-            m_intake.SetFunnel(0.4);
-
-            if (m_drivetrain.AtGoal()) {
-                state = State::kDriveBack;
-            }
-            break;
-        }
-        case State::kDriveBack: {
-            m_intake.SetArmMotor(Intake::ArmMotorDirection::kIdle);
-            m_intake.SetFunnel(0.0);
-
-            auto config = Drivetrain::MakeTrajectoryConfig();
-            config.SetReversed(true);
-
-            m_drivetrain.SetWaypoints(endPose, {}, midPose, config);
-            state = State::kTrenchShoot;
-            break;
-        }
-        case State::kTrenchShoot: {
-            // Shoot x3
-            if (m_drivetrain.AtGoal()) {
-                Shoot();
-                state = State::kIdle;
-            }
-            break;
-        }
-        case State::kIdle: {
-            break;
+    while (IsShooting()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
         }
     }
 
-    if constexpr (IsSimulation()) {
-        if (autonTimer.HasElapsed(14.97_s)) {
-            EXPECT_EQ(State::kIdle, state);
+    frc::RectangularRegionConstraint regionConstraint{
+        // X: Leftmost ball on trench run
+        frc::Translation2d{endPose.X(), 0.71_m - 0.5 * Drivetrain::kLength},
+        // X: Rightmost ball on trench run
+        frc::Translation2d{9.82_m + 0.5 * Drivetrain::kLength,
+                           0.71_m + 0.5 * Drivetrain::kLength},
+        frc::MaxVelocityConstraint{1.6_mps}};
+
+    // Add a constraint to slow down the drivetrain while it's
+    // approaching the balls. Interior translation is first/closest ball in
+    // trench run.
+    {
+        auto config = Drivetrain::MakeTrajectoryConfig();
+        config.AddConstraint(regionConstraint);
+        m_drivetrain.SetWaypoints({initialPose, midPose, endPose}, config);
+    }
+
+    // Intake Balls x3
+    m_intake.SetArmMotor(Intake::ArmMotorDirection::kIntake);
+    m_intake.SetFunnel(0.4);
+
+    while (!m_drivetrain.AtGoal()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
+        }
+    }
+
+    m_intake.SetArmMotor(Intake::ArmMotorDirection::kIdle);
+    m_intake.SetFunnel(0.0);
+
+    // Drive back
+    {
+        auto config = Drivetrain::MakeTrajectoryConfig();
+        config.SetReversed(true);
+        m_drivetrain.SetWaypoints(endPose, {}, midPose, config);
+    }
+
+    while (!m_drivetrain.AtGoal()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
+        }
+    }
+
+    // Shoot x3
+    Shoot();
+
+    while (IsShooting()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
         }
     }
 }
+
 }  // namespace frc3512

--- a/src/main/cpp/autonomous/AutoTargetZoneShootThree.cpp
+++ b/src/main/cpp/autonomous/AutoTargetZoneShootThree.cpp
@@ -7,52 +7,31 @@
 
 namespace frc3512 {
 
-namespace {
-enum class State { kInit, kDriveAwayFromGoal, kIdle };
-}  // namespace
+void Robot::AutoTargetZoneShootThree() {
+    const frc::Pose2d initialPose{12.89_m, 2.41_m,
+                                  units::radian_t{wpi::math::pi}};
+    const frc::Pose2d endPose{12.89_m - 1.5 * Drivetrain::kLength, 2.41_m,
+                              units::radian_t{wpi::math::pi}};
 
-static State state;
-static frc2::Timer autonTimer;
-
-static const frc::Pose2d initialPose{12.89_m, 2.41_m,
-                                     units::radian_t{wpi::math::pi}};
-static const frc::Pose2d endPose{12.89_m - 1.5 * Drivetrain::kLength, 2.41_m,
-                                 units::radian_t{wpi::math::pi}};
-
-void Robot::AutoTargetZoneShootThreeInit() {
     m_drivetrain.Reset(initialPose);
+    m_drivetrain.SetWaypoints(initialPose, {}, endPose);
 
-    state = State::kInit;
-    autonTimer.Reset();
-    autonTimer.Start();
-}
-
-void Robot::AutoTargetZoneShootThreePeriodic() {
-    switch (state) {
-        case State::kInit: {
-            m_drivetrain.SetWaypoints(initialPose, {}, endPose);
-            state = State::kDriveAwayFromGoal;
-            break;
-        }
-        case State::kDriveAwayFromGoal: {
-            if (m_drivetrain.AtGoal()) {
-                // Shoot x3
-                Shoot();
-                state = State::kIdle;
-            }
-            break;
-        }
-        case State::kIdle: {
-            break;
+    while (!m_drivetrain.AtGoal()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
         }
     }
 
-    if constexpr (IsSimulation()) {
-        if (autonTimer.HasElapsed(14.5_s)) {
-            EXPECT_EQ(State::kIdle, state);
-            EXPECT_TRUE(m_drivetrain.AtGoal());
-            EXPECT_EQ(m_flywheel.GetGoal(), 0_rad_per_s);
-            EXPECT_TRUE(m_turret.AtGoal());
+    // Shoot x3
+    Shoot();
+
+    while (IsShooting()) {
+        m_autonChooser.Yield();
+        if (!IsAutonomousEnabled()) {
+            EXPECT_TRUE(false) << "Autonomous mode didn't complete";
+            return;
         }
     }
 }

--- a/src/main/cpp/subsystems/Vision.cpp
+++ b/src/main/cpp/subsystems/Vision.cpp
@@ -5,7 +5,6 @@
 #include <chrono>
 #include <vector>
 
-#include <frc/RobotBase.h>
 #include <frc/geometry/Pose2d.h>
 #include <frc/geometry/Transform2d.h>
 #include <frc2/Timer.h>

--- a/src/main/include/AutonomousChooser.hpp
+++ b/src/main/include/AutonomousChooser.hpp
@@ -2,9 +2,10 @@
 
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <string>
-#include <tuple>
+#include <thread>
 #include <vector>
 
 #include <frc/smartdashboard/Sendable.h>
@@ -12,6 +13,7 @@
 #include <networktables/NetworkTableEntry.h>
 #include <wpi/StringMap.h>
 #include <wpi/StringRef.h>
+#include <wpi/condition_variable.h>
 #include <wpi/mutex.h>
 
 namespace frc3512 {
@@ -28,38 +30,20 @@ public:
      * Adds an autonomous mode that's run by default if no other autonomous mode
      * is selected.
      *
-     * @param name         Name of autonomous mode.
-     * @param initFunc     Init() function for autonomous mode that will run in
-     *                     AutonomousInit().
-     * @param periodicFunc Periodic() function for autonomous mode that will run
-     *                     in AutonomousPeriodic().
+     * @param name Name of autonomous mode.
+     * @param func Autonomous mode function.
      */
-    AutonomousChooser(wpi::StringRef name, std::function<void()> initFunc,
-                      std::function<void()> periodicFunc);
+    AutonomousChooser(wpi::StringRef name, std::function<void()> func);
 
     ~AutonomousChooser();
 
     /**
      * Adds an autonomous mode.
      *
-     * @param name         Name of autonomous mode.
-     * @param initFunc     Init() function for autonomous mode that will run in
-     *                     AutonomousInit().
-     * @param periodicFunc Periodic() function for autonomous mode that will run
-     *                     in AutonomousPeriodic().
+     * @param name Name of autonomous mode.
+     * @param func Autonomous mode function.
      */
-    void AddAutonomous(wpi::StringRef name, std::function<void()> initFunc,
-                       std::function<void()> periodicFunc);
-
-    /**
-     * Runs the Init() function of the selected autonomous mode.
-     */
-    void RunAutonomousInit();
-
-    /**
-     * Runs the Periodic() function of the selected autonomous mode.
-     */
-    void RunAutonomousPeriodic();
+    void AddAutonomous(wpi::StringRef name, std::function<void()> func);
 
     /**
      * Sets the selected autonomous mode for unit testing purposes.
@@ -73,19 +57,58 @@ public:
      */
     const std::vector<std::string>& GetAutonomousNames() const;
 
+    /**
+     * Yield to main robot thread and wait for next chance to run.
+     *
+     * This function should only be called by the autonomous mode. A call by the
+     * main robot thread will block indefinitely.
+     */
+    void Yield();
+
+    /**
+     * Return to main robot thread.
+     *
+     * This function should only be called by the autonomous mode.
+     */
+    void Return();
+
+    /**
+     * Runs the selected autonomous mode function.
+     */
+    void AwaitStartAutonomous();
+
+    /**
+     * Notify autonomous mode to run.
+     *
+     * This function should only be called by the main robot thread. It will
+     * block until the autonomous mode function waits to be run again. This
+     * ensures the main robot thread and autonomous mode won't race for
+     * resources.
+     */
+    void AwaitRunAutonomous();
+
+    /**
+     * Notify autonomous mode so it can exit.
+     */
+    void EndAutonomous();
+
     void InitSendable(frc::SendableBuilder& builder) override;
 
 private:
-    using AutonomousContainer =
-        std::tuple<std::function<void()>, std::function<void()>>;
-
+    std::thread m_autonThread;
     wpi::mutex m_mutex;
+    wpi::mutex m_autonMutex;
+    std::unique_lock<wpi::mutex> m_mainLock{m_autonMutex};
+    std::unique_lock<wpi::mutex> m_autonLock{m_autonMutex, std::defer_lock};
+    wpi::condition_variable m_cond;
+    bool m_awaitingAuton = false;
+    bool m_autonRunning = false;
 
     std::string m_defaultChoice;
     std::string m_selectedChoice;
-    wpi::StringMap<AutonomousContainer> m_choices;
+    wpi::StringMap<std::function<void()>> m_choices;
     std::vector<std::string> m_names;
-    AutonomousContainer m_selectedAuton;
+    std::function<void()>* m_selectedAuton;
 
     nt::NetworkTableEntry m_defaultEntry;
     nt::NetworkTableEntry m_optionsEntry;

--- a/src/main/include/Robot.hpp
+++ b/src/main/include/Robot.hpp
@@ -12,11 +12,16 @@
 #if RUNNING_FRC_TESTS
 #include <gtest/gtest.h>
 #else
-#define EXPECT_EQ(a, b)
-#define EXPECT_FALSE(a)
-#define EXPECT_GT(a, b)
-#define EXPECT_LT(a, b)
-#define EXPECT_TRUE(a)
+namespace frc3512::testing {
+struct NoOp {
+    void operator<<(const char*) {}
+};
+}  // namespace frc3512::testing
+#define EXPECT_EQ(a, b) frc3512::testing::NoOp()
+#define EXPECT_FALSE(a) frc3512::testing::NoOp()
+#define EXPECT_GT(a, b) frc3512::testing::NoOp()
+#define EXPECT_LT(a, b) frc3512::testing::NoOp()
+#define EXPECT_TRUE(a) frc3512::testing::NoOp()
 #endif
 
 #include "AutonomousChooser.hpp"
@@ -86,130 +91,63 @@ public:
     void RunShooterSM();
 
     /**
-     * Initialization code for no-op autonomous.
+     * No-op autonomous.
      */
-    void AutoNoOpInit();
+    void AutoNoOp();
 
     /**
-     * Initialization code for driving towards the allied alliance station from
-     * the initiation line and in front of the loading zone.
-     */
-    void AutoLoadingZoneDriveForwardInit();
-
-    /**
-     * Initialization code for shooting three power cells from the initiation
-     * line in front of the loading zone.
-     */
-    void AutoLoadingZoneShootThreeInit();
-
-    /**
-     * Initialization code for shooting three power cells from the initiation
-     * line in front of the target zone.
-     */
-    void AutoTargetZoneShootThreeInit();
-
-    /**
-     * Initialization code for driving towards the allied alliance station from
-     * the initiation line in front of the allied trench run.
-     */
-    void AutoRightSideDriveForwardInit();
-
-    /**
-     * Initialization code for shooting three power cells from the initiation
-     * line in front of the allied trench run.
-     */
-    void AutoRightSideShootThreeInit();
-
-    /**
-     * Initialization code for shooting three power cells from the initiation
-     * line in front of the opposing trench run and intaking two balls in the
-     * trench run.
-     */
-    void AutoLeftSideIntakeInit();
-
-    /**
-     * Initialization code for shooting three power cells from the initiation
-     * line in front of the allied trench run and intaking three balls in the
-     * trench run.
-     */
-    void AutoRightSideIntakeInit();
-
-    /**
-     * Initialization code for shooting three power cells from the initiation
-     * line in front of the allied trench run, intaking three balls in the
-     * trench run, then shooting them.
-     */
-    void AutoRightSideShootSixInit();
-
-    /**
-     * Initialization code for shooting three power cells from the initiation
-     * line in front of the target zone, intaking two balls under the power
-     * generator, then shooting them.
-     */
-    void AutoTargetZoneShootSixInit();
-
-    /**
-     * Periodic code for no-op autonomous.
-     */
-    void AutoNoOpPeriodic();
-
-    /**
-     * Periodic code for driving towards the allied alliance station from the
-     * initiation line and in front of the loading zone.
-     */
-    void AutoLoadingZoneDriveForwardPeriodic();
-
-    /**
-     * Periodic code for shooting three power cells from the initiation line in
+     * Drive towards the allied alliance station from the initiation line and in
      * front of the loading zone.
      */
-    void AutoLoadingZoneShootThreePeriodic();
+    void AutoLoadingZoneDriveForward();
 
     /**
-     * Periodic code for shooting three power cells from the initiation line in
-     * front of the target zone.
+     * Shoot three power cells from the initiation line in front of the loading
+     * zone.
      */
-    void AutoTargetZoneShootThreePeriodic();
+    void AutoLoadingZoneShootThree();
 
     /**
-     * Periodic code for driving towards the allied alliance station from the
-     * initiation line in front of the allied trench run.
+     * Shoot three power cells from the initiation line in front of the target
+     * zone.
      */
-    void AutoRightSideDriveForwardPeriodic();
+    void AutoTargetZoneShootThree();
 
     /**
-     * Periodic code for shooting three power cells from the initiation line in
+     * Drive towards the allied alliance station from the initiation line in
      * front of the allied trench run.
      */
-    void AutoRightSideShootThreePeriodic();
+    void AutoRightSideDriveForward();
 
     /**
-     * Periodic code for shooting three power cells from the initiation line in
-     * front of the opposing trench run and intaking two balls in the trench
-     * run.
+     * Shoot three power cells from the initiation line in front of the allied
+     * trench run.
      */
-    void AutoLeftSideIntakePeriodic();
+    void AutoRightSideShootThree();
 
     /**
-     * Periodic code for shooting three power cells from the initiation line in
-     * front of the allied trench run and intaking three balls in the trench
-     * run.
+     * Shoot three power cells from the initiation line in front of the opposing
+     * trench run and intake two balls in the trench run.
      */
-    void AutoRightSideIntakePeriodic();
+    void AutoLeftSideIntake();
 
     /**
-     * Periodic code for shooting three power cells from the initiation line in
-     * front of the allied trench run, intaking three balls in the trench run,
-     * then shooting them.
+     * Shoot three power cells from the initiation line in front of the allied
+     * trench run and intake three balls in the trench run.
      */
-    void AutoRightSideShootSixPeriodic();
+    void AutoRightSideIntake();
 
     /**
-     * Periodic code for shooting three power cells from the initiation line in
-     * front of the target zone, intaking two balls under the power generator,
-     * then shooting them.
+     * Shoot three power cells from the initiation line in front of the allied
+     * trench run, intake three balls in the trench run, then shooting them.
      */
-    void AutoTargetZoneShootSixPeriodic();
+    void AutoRightSideShootSix();
+
+    /**
+     * Shoot three power cells from the initiation line in front of the target
+     * zone, intake two balls under the power generator, then shoot them.
+     */
+    void AutoTargetZoneShootSix();
 
     /**
      * Sets the selected autonomous mode for testing purposes.
@@ -243,8 +181,7 @@ private:
     ShootingState m_state = ShootingState::kIdle;
     frc2::Timer m_timer;
 
-    AutonomousChooser m_autonChooser{"No-op", [=] { AutoNoOpInit(); },
-                                     [=] { AutoNoOpPeriodic(); }};
+    AutonomousChooser m_autonChooser{"No-op", [=] { AutoNoOp(); }};
 
     frc::CSVLogFile m_batteryLogger{"Battery", "Battery voltage (V)"};
 };


### PR DESCRIPTION
This make the autonomous mode logic procedural instead of imperative,
which is much easier to read and write. AutonomousChooser uses condition
variables to ensure the main robot thread and separate autonomous mode
thread don't run concurrently to avoid potential race conditions and
avoid the need for synchronization in user code.