### PR TITLE
Remove duplicate battery voltage compensation from subsystems

### DIFF
--- a/src/main/cpp/controllers/FlywheelController.cpp
+++ b/src/main/cpp/controllers/FlywheelController.cpp
@@ -40,7 +40,6 @@ Eigen::Matrix<double, 1, 1> FlywheelController::Calculate(
         m_u = m_lqr.Calculate(x, m_r) + m_ff.Calculate(m_nextR);
     }
 
-    m_u *= 12.0 / frc::RobotController::GetInputVoltage();
     m_u = frc::NormalizeInputVector<1>(m_u, 12.0);
 
     // m_nextR is used here so AtGoal() returns false after calling SetGoal()

--- a/src/main/cpp/controllers/TurretController.cpp
+++ b/src/main/cpp/controllers/TurretController.cpp
@@ -155,7 +155,6 @@ Eigen::Matrix<double, 1, 1> TurretController::Calculate(
             m_u << 0.0;
         }
 
-        m_u *= 12.0 / frc::RobotController::GetInputVoltage();
         m_u = frc::NormalizeInputVector<1>(m_u, 12.0);
 
         UpdateAtReferences(m_nextR - x);


### PR DESCRIPTION
Currently we mulitply input voltage twice on turret and flywheel
controller when we only want it to happen once.