### PR TITLE
Move controller logging to a separate low priority thread

### DIFF
--- a/src/main/cpp/subsystems/Flywheel.cpp
+++ b/src/main/cpp/subsystems/Flywheel.cpp
@@ -109,15 +109,11 @@ units::radians_per_second_t Flywheel::GetReferenceForPose(
 }
 
 void Flywheel::RobotPeriodic() {
-    m_isOnEntry.SetBoolean(IsOn());
-    m_isReadyEntry.SetBoolean(IsReady());
-
     if (frc::DriverStation::GetInstance().IsTest()) {
         static frc::Joystick appendageStick2{kAppendageStick2Port};
 
         m_testThrottle = appendageStick2.GetThrottle();
         auto manualRef = ThrottleToReference(m_testThrottle);
-        m_manualAngularVelocityReferenceEntry.SetDouble(manualRef.to<double>());
         fmt::print("Manual angular velocity: {}\n", manualRef);
     }
 }

--- a/src/main/cpp/subsystems/Turret.cpp
+++ b/src/main/cpp/subsystems/Turret.cpp
@@ -114,9 +114,6 @@ const Eigen::Matrix<double, 2, 1>& Turret::GetStates() const {
 }
 
 void Turret::RobotPeriodic() {
-    m_ccwLimitSwitchValueEntry.SetBoolean(m_ccwLimitSwitch.Get());
-    m_cwLimitSwitchValueEntry.SetBoolean(m_cwLimitSwitch.Get());
-
     if (!frc::DriverStation::GetInstance().IsDisabled()) {
         auto turretHeadingInGlobal = units::radian_t{
             GetStates()(TurretController::State::kAngle) +
@@ -128,15 +125,6 @@ void Turret::RobotPeriodic() {
         }
     } else {
         m_vision.TurnLEDOff();
-    }
-
-    int controlMode = static_cast<int>(m_controller.GetControlMode());
-    if (controlMode == 0) {
-        m_controlModeEntry.SetString("Manual");
-    } else if (controlMode == 1) {
-        m_controlModeEntry.SetString("ClosedLoop");
-    } else if (controlMode == 2) {
-        m_controlModeEntry.SetString("AutoAim");
     }
 }
 
@@ -212,8 +200,6 @@ void Turret::ControllerPeriodic() {
                 globalMeasurement.value().timestamp);
         } else {
             m_poseMeasurementFaultCounter++;
-            m_poseMeasurementFaultEntry.SetDouble(
-                m_poseMeasurementFaultCounter);
         }
     }
 

--- a/src/main/include/subsystems/Drivetrain.hpp
+++ b/src/main/include/subsystems/Drivetrain.hpp
@@ -28,7 +28,6 @@
 #include <units/velocity.h>
 
 #include "Constants.hpp"
-#include "NetworkTableUtil.hpp"
 #include "controllers/DrivetrainController.hpp"
 #include "rev/CANSparkMax.hpp"
 #include "subsystems/ControlledSubsystemBase.hpp"

--- a/src/main/include/subsystems/Flywheel.hpp
+++ b/src/main/include/subsystems/Flywheel.hpp
@@ -12,8 +12,6 @@
 #include <frc/system/LinearSystem.h>
 #include <frc/system/plant/LinearSystemId.h>
 #include <frc2/Timer.h>
-#include <networktables/NetworkTableEntry.h>
-#include <networktables/NetworkTableInstance.h>
 #include <units/angle.h>
 #include <units/angular_velocity.h>
 #include <units/current.h>
@@ -23,7 +21,6 @@
 #include "Constants.hpp"
 #include "FlywheelSim.hpp"
 #include "LerpTable.hpp"
-#include "NetworkTableUtil.hpp"
 #include "controllers/FlywheelController.hpp"
 #include "rev/CANSparkMax.hpp"
 #include "subsystems/ControlledSubsystemBase.hpp"
@@ -167,14 +164,6 @@ private:
     // Used in test mode for manually setting flywheel goal. This is helpful for
     // measuring flywheel lookup table values.
     double m_testThrottle = 0.0;
-
-    nt::NetworkTableEntry m_isOnEntry =
-        NetworkTableUtil::MakeBoolEntry("/Diagnostics/Flywheel/IsOn", false);
-    nt::NetworkTableEntry m_isReadyEntry =
-        NetworkTableUtil::MakeBoolEntry("/Diagnostics/Flywheel/IsReady", false);
-    nt::NetworkTableEntry m_manualAngularVelocityReferenceEntry =
-        NetworkTableUtil::MakeDoubleEntry(
-            "/Diagnostics/Flywheel/Manual angular velocity reference", 0.0);
 
     // Measurement noise isn't added because the simulated encoder stores the
     // count as an integer, which already introduces quantization noise.

--- a/src/main/include/subsystems/Turret.hpp
+++ b/src/main/include/subsystems/Turret.hpp
@@ -10,15 +10,12 @@
 #include <frc/simulation/AnalogInputSim.h>
 #include <frc/simulation/DutyCycleEncoderSim.h>
 #include <frc/simulation/LinearSystemSim.h>
-#include <networktables/NetworkTableEntry.h>
-#include <networktables/NetworkTableInstance.h>
 #include <units/angle.h>
 #include <units/current.h>
 #include <units/voltage.h>
 
 #include "ADCInput.hpp"
 #include "Constants.hpp"
-#include "NetworkTableUtil.hpp"
 #include "controllers/TurretController.hpp"
 #include "rev/CANSparkMax.hpp"
 #include "subsystems/ControlledSubsystemBase.hpp"
@@ -169,18 +166,6 @@ private:
     Flywheel& m_flywheel;
 
     uint32_t m_poseMeasurementFaultCounter = 0;
-    nt::NetworkTableEntry m_controlModeEntry =
-        NetworkTableUtil::MakeStringEntry("/Diagnostics/Turret/Control mode",
-                                          "Manual");
-    nt::NetworkTableEntry m_poseMeasurementFaultEntry =
-        NetworkTableUtil::MakeDoubleEntry(
-            "/Diagnostics/Turret/Measurement fault counter", 0.0);
-    nt::NetworkTableEntry m_ccwLimitSwitchValueEntry =
-        NetworkTableUtil::MakeBoolEntry(
-            "/Diagnostics/Turret/CCW hard limit triggered", true);
-    nt::NetworkTableEntry m_cwLimitSwitchValueEntry =
-        NetworkTableUtil::MakeBoolEntry(
-            "/Diagnostics/Turret/CW hard limit triggered", true);
 
     // Simulation variables
     frc::sim::LinearSystemSim<2, 1, 1> m_turretSim{m_controller.GetPlant(),


### PR DESCRIPTION
This patch makes logger classes receive all data through a thread-safe queue on
another thread that actually writes the NT data or CSV file. This moves
the file and socket I/O overhead out of the controller, which improves
their scheduling jitter.