### PR TITLE
Create an enable/disable diagnostics function

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -226,8 +226,13 @@ void Robot::RobotPeriodic() {
     m_batteryLogger.Log(
         units::second_t{std::chrono::steady_clock::now().time_since_epoch()},
         batteryVoltage);
-    m_batteryVoltageEntry.SetDouble(batteryVoltage);
-    m_ballsToShootEntry.SetDouble(m_ballsToShoot);
+
+    auto sendDiagnostics =
+        NetworkTableUtil::MakeBoolEntry("/Diagnostics/SendDiagnostics", false);
+    if (sendDiagnostics.GetBoolean(false)) {
+        m_batteryVoltageEntry.SetDouble(batteryVoltage);
+        m_ballsToShootEntry.SetDouble(m_ballsToShoot);
+    }
 }
 
 void Robot::SimulationPeriodic() {

--- a/src/main/include/subsystems/ControlledSubsystemBase.hpp
+++ b/src/main/include/subsystems/ControlledSubsystemBase.hpp
@@ -9,6 +9,7 @@
 
 #include <Eigen/Core>
 #include <fmt/core.h>
+#include <frc/DriverStation.h>
 #include <frc/RobotBase.h>
 #include <frc/Threads.h>
 #include <frc/fmt/Units.h>
@@ -21,6 +22,7 @@
 #include <wpi/Twine.h>
 
 #include "Constants.hpp"
+#include "NetworkTableUtil.hpp"
 #include "RealTimePriorities.hpp"
 #include "logging/CSVControllerLogger.hpp"
 #include "logging/NTControllerLogger.hpp"
@@ -200,7 +202,13 @@ private:
 
             m_csvLogger.Log(entry.nowBegin - frc::CSVLogFile::GetStartTime(),
                             entry.r, entry.x, entry.u, entry.y);
-            m_ntLogger.Log(entry.r, entry.x, entry.u, entry.y);
+
+            auto sendDiagnostics = NetworkTableUtil::MakeBoolEntry(
+                "/Diagnostics/SendDiagnostics", false);
+            if (sendDiagnostics.GetBoolean(false) &&
+                !frc::DriverStation::GetInstance().IsFMSAttached()) {
+                m_ntLogger.Log(entry.r, entry.x, entry.u, entry.y);
+            }
 
             m_timingLogger.Log(
                 entry.nowBegin - frc::CSVLogFile::GetStartTime(),


### PR DESCRIPTION
Allows users to enable diagnostic data in the case something goes wrong. Disabled by default. Helps save on bandwidth during a competition.

Closes #135 