### PR TITLE
Implement yaw and pitch measurements for shooting

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -162,7 +162,7 @@ void Robot::Shoot(int ballsToShoot) {
         }
 
         m_eventLogger.Log(
-            fmt::format("Called Robot::Shoot({}", m_ballsToShoot));
+            fmt::format("Called Robot::Shoot({})", m_ballsToShoot));
     }
 }
 
@@ -259,7 +259,10 @@ void Robot::RobotPeriodic() {
         RunShooterSM();
     }
 
-    /*units::radian_t turretHeadingInGlobal{
+// Sets camera's leds on when "facing" the target. Global measurements are
+// off during testing and would shut off leds in unwanted situations.
+#if 0
+    units::radian_t turretHeadingInGlobal{
         turret.GetStates()(TurretController::State::kAngle) +
         drivetrain.GetStates()(DrivetrainController::State::kHeading)};
     if (!ds.IsDisabled() &&
@@ -268,7 +271,8 @@ void Robot::RobotPeriodic() {
         vision.TurnLEDOn();
     } else {
         vision.TurnLEDOff();
-    }*/
+    }
+#endif
 
     auto batteryVoltage = frc::RobotController::GetInputVoltage();
     m_batteryLogger.Log(
@@ -331,7 +335,7 @@ void Robot::RunShooterSM() {
                        m_visionTimer.HasElapsed(3_s)) {
                 m_visionTimer.Stop();
                 vision.TurnLEDOff();
-                fmt::print("Target not found!");
+                fmt::print(stderr, "Target not found!\n");
                 m_state = ShootingState::kIdle;
             }
             break;

--- a/src/main/cpp/subsystems/Flywheel.cpp
+++ b/src/main/cpp/subsystems/Flywheel.cpp
@@ -111,7 +111,7 @@ units::radians_per_second_t Flywheel::GetReferenceForPose(
 }
 
 units::radians_per_second_t Flywheel::GetReferenceForRange(
-    const units::meter_t& range) const {
+    units::meter_t range) const {
     return m_table[range];
 }
 

--- a/src/main/cpp/subsystems/Flywheel.cpp
+++ b/src/main/cpp/subsystems/Flywheel.cpp
@@ -39,12 +39,13 @@ Flywheel::Flywheel(Drivetrain& drivetrain)
     m_leftGrbx.SetInverted(false);
     m_rightGrbx.SetInverted(false);
 
-    m_table.Insert(125_in, 468_rad_per_s);
-    m_table.Insert(175_in, 480_rad_per_s);
-    m_table.Insert(200_in, 505_rad_per_s);
-    m_table.Insert(231_in, 508_rad_per_s);
-    m_table.Insert(312_in, 598_rad_per_s);
-    m_table.Insert(360_in, 708_rad_per_s);
+    // Vision loses target past 295_in
+    m_table.Insert(125_in, 489_rad_per_s);
+    m_table.Insert(175_in, 501_rad_per_s);
+    m_table.Insert(200_in, 647_rad_per_s);
+    m_table.Insert(231_in, 659_rad_per_s);
+    m_table.Insert(312_in, 690_rad_per_s);
+    m_table.Insert(360_in, 759_rad_per_s);
 
     Reset();
     SetGoal(0_rad_per_s);
@@ -80,6 +81,10 @@ void Flywheel::SetGoalFromPose() {
     }
 }
 
+void Flywheel::SetGoalFromVision() {
+    SetGoal(GetReferenceForRange(m_distanceToTarget));
+}
+
 bool Flywheel::IsOn() const { return GetGoal() > 0_rad_per_s; }
 
 bool Flywheel::IsReady() { return GetGoal() > 0_rad_per_s && AtGoal(); }
@@ -105,6 +110,11 @@ units::radians_per_second_t Flywheel::GetReferenceForPose(
         TargetModel::kTargetPoseInGlobal.Translation())];
 }
 
+units::radians_per_second_t Flywheel::GetReferenceForRange(
+    const units::meter_t& range) const {
+    return m_table[range];
+}
+
 void Flywheel::RobotPeriodic() {
     if (frc::DriverStation::GetInstance().IsTest()) {
         static frc::Joystick appendageStick2{HWConfig::kAppendageStick2Port};
@@ -112,6 +122,12 @@ void Flywheel::RobotPeriodic() {
         m_testThrottle = appendageStick2.GetThrottle();
         auto manualRef = ThrottleToReference(m_testThrottle);
         fmt::print("Manual angular velocity: {}\n", manualRef);
+    }
+
+    auto visionData = visionQueue.pop();
+    if (visionData.has_value()) {
+        const auto& measurement = visionData.value();
+        m_distanceToTarget = measurement.range;
     }
 }
 

--- a/src/main/cpp/subsystems/Turret.cpp
+++ b/src/main/cpp/subsystems/Turret.cpp
@@ -188,6 +188,13 @@ void Turret::ControllerPeriodic() {
     y << GetAngle().to<double>();
     m_observer.Correct(m_controller.GetInputs(), y);
 
+    auto visionData = visionQueue.pop();
+    if (visionData.has_value()) {
+        m_controller.SetVisionMeasurements(visionData.value().yaw,
+                                           visionData.value().timestamp);
+        m_controllerYawEntry.SetDouble(visionData.value().yaw.to<double>());
+    }
+
     m_u = m_controller.Calculate(m_observer.Xhat());
 
     // Set motor input

--- a/src/main/cpp/subsystems/Vision.cpp
+++ b/src/main/cpp/subsystems/Vision.cpp
@@ -29,9 +29,7 @@ frc::Transform2d operator+(const frc::Transform2d& first,
         frc::Pose2d{}, frc::Pose2d{}.TransformBy(first).TransformBy(second)};
 }
 
-Vision::Vision(Turret& turret) : m_turret(turret) {
-    fmt::print("Target Height: {}", TargetModel::kCenter.Z().to<double>());
-}
+Vision::Vision(Turret& turret) : m_turret(turret) {}
 
 void Vision::TurnLEDOn() { m_rpiCam.SetLEDMode(photonlib::LEDMode::kOn); }
 
@@ -119,9 +117,9 @@ void Vision::RobotPeriodic() {
 
     m_yawEntry.SetDouble(units::radian_t{m_yaw}.to<double>());
 
-    units::meter_t range = (photonlib::PhotonUtils::CalculateDistanceToTarget(
+    units::meter_t range = photonlib::PhotonUtils::CalculateDistanceToTarget(
         kCameraHeight, TargetModel::kCenter.Z(), kCameraPitch,
-        units::degree_t{m_pitch}));
+        units::degree_t{m_pitch});
 
     std::scoped_lock lock{m_subsystemQueuesMutex};
     for (auto& queue : m_subsystemQueues) {

--- a/src/main/cpp/subsystems/Vision.cpp
+++ b/src/main/cpp/subsystems/Vision.cpp
@@ -5,13 +5,17 @@
 #include <chrono>
 #include <vector>
 
+#include <fmt/format.h>
 #include <frc/DriverStation.h>
+#include <frc/Joystick.h>
 #include <frc/RobotBase.h>
 #include <frc/geometry/Pose2d.h>
 #include <frc/geometry/Transform2d.h>
 #include <frc2/Timer.h>
+#include <photonlib/PhotonUtils.h>
 #include <units/angle.h>
 
+#include "TargetModel.hpp"
 #include "subsystems/Turret.hpp"
 
 using namespace frc3512;
@@ -25,7 +29,9 @@ frc::Transform2d operator+(const frc::Transform2d& first,
         frc::Pose2d{}, frc::Pose2d{}.TransformBy(first).TransformBy(second)};
 }
 
-Vision::Vision(Turret& turret) : m_turret(turret) {}
+Vision::Vision(Turret& turret) : m_turret(turret) {
+    fmt::print("Target Height: {}", TargetModel::kCenter.Z().to<double>());
+}
 
 void Vision::TurnLEDOn() { m_rpiCam.SetLEDMode(photonlib::LEDMode::kOn); }
 
@@ -58,6 +64,8 @@ void Vision::UpdateVisionMeasurementsSim(
     m_simVision.ProcessFrame(drivetrainPose);
 }
 
+bool Vision::IsTargetDetected() const { return m_isTargetDetected; }
+
 void Vision::SimulationInit() {
     m_simVision.MoveCamera(frc::Transform2d{}, kCameraHeight, kCameraPitch);
 
@@ -72,13 +80,21 @@ void Vision::SimulationInit() {
 }
 
 void Vision::RobotPeriodic() {
+    static frc::Joystick appendageStick2{HWConfig::kAppendageStick2Port};
+
+    if (appendageStick2.GetRawButtonPressed(5)) {
+        TurnLEDOn();
+    }
+
     const auto& result = m_rpiCam.GetLatestResult();
 
     if (result.GetTargets().size() == 0 ||
         frc::DriverStation::GetInstance().IsDisabled()) {
+        m_isTargetDetected = false;
         return;
     }
 
+    m_isTargetDetected = true;
     auto timestamp = frc2::Timer::GetFPGATimestamp() - result.GetLatency();
 
     photonlib::PhotonTrackedTarget target = result.GetBestTarget();
@@ -97,10 +113,21 @@ void Vision::RobotPeriodic() {
         drivetrainInGlobal.Y().to<double>(),
         drivetrainInGlobal.Rotation().Radians().to<double>()};
     m_poseEntry.SetDoubleArray(pose);
-    m_yawEntry.SetDouble(target.GetYaw());
+
+    m_pitch = units::degree_t{target.GetPitch()};
+    m_yaw = units::degree_t{target.GetYaw()};
+
+    m_yawEntry.SetDouble(units::radian_t{m_yaw}.to<double>());
+
+    units::meter_t range = (photonlib::PhotonUtils::CalculateDistanceToTarget(
+        kCameraHeight, TargetModel::kCenter.Z(), kCameraPitch,
+        units::degree_t{m_pitch}));
 
     std::scoped_lock lock{m_subsystemQueuesMutex};
     for (auto& queue : m_subsystemQueues) {
-        queue->push({drivetrainInGlobal, timestamp});
+        queue->push({drivetrainInGlobal, timestamp, units::radian_t{m_yaw},
+                     units::radian_t{m_pitch}, range});
     }
+
+    m_rangeEntry.SetDouble(range.to<double>());
 }

--- a/src/main/cpp/subsystems/Vision.cpp
+++ b/src/main/cpp/subsystems/Vision.cpp
@@ -5,7 +5,6 @@
 #include <chrono>
 #include <vector>
 
-#include <fmt/format.h>
 #include <frc/DriverStation.h>
 #include <frc/Joystick.h>
 #include <frc/RobotBase.h>
@@ -121,10 +120,12 @@ void Vision::RobotPeriodic() {
         kCameraHeight, TargetModel::kCenter.Z(), kCameraPitch,
         units::degree_t{m_pitch});
 
-    std::scoped_lock lock{m_subsystemQueuesMutex};
-    for (auto& queue : m_subsystemQueues) {
-        queue->push({drivetrainInGlobal, timestamp, units::radian_t{m_yaw},
-                     units::radian_t{m_pitch}, range});
+    {
+        std::scoped_lock lock{m_subsystemQueuesMutex};
+        for (auto& queue : m_subsystemQueues) {
+            queue->push({drivetrainInGlobal, timestamp, units::radian_t{m_yaw},
+                         units::radian_t{m_pitch}, range});
+        }
     }
 
     m_rangeEntry.SetDouble(range.to<double>());

--- a/src/main/include/Robot.hpp
+++ b/src/main/include/Robot.hpp
@@ -52,7 +52,12 @@ public:
     /**
      * States used for the multi-subsystem shooting procedure
      */
-    enum class ShootingState { kIdle, kStartFlywheel, kStartConveyor };
+    enum class ShootingState {
+        kIdle,
+        kFindTarget,
+        kStartFlywheel,
+        kStartConveyor
+    };
 
     /// Maximum time for which to run flywheel.
     static constexpr auto kMaxShootTimeout = 3_s;
@@ -315,6 +320,8 @@ private:
     units::second_t m_shootTimeout = kMaxShootTimeout;
     bool m_prevFlywheelAtGoal = false;
     frc2::Timer m_timer;
+
+    frc2::Timer m_visionTimer;
 
     nt::NetworkTableEntry m_LEDEntry =
         NetworkTableUtil::MakeBoolEntry("/photonvision/ledMode");

--- a/src/main/include/controllers/TurretController.hpp
+++ b/src/main/include/controllers/TurretController.hpp
@@ -44,7 +44,9 @@ public:
         /// Closed loop without auto-aiming
         kClosedLoop,
         /// Closed loop with auto-aiming
-        kAutoAim
+        kAutoAim,
+        /// Closed loop with Vision data
+        kVisionAim
     };
 
     /**
@@ -158,6 +160,14 @@ public:
     void SetControlMode(ControlMode mode);
 
     /**
+     * Set yaw and timestamp of the vision measurment.
+     *
+     * @param yaw yaw measurement in radians from the vision subsystem.
+     * @param timestamp the corresponding timestamp for the yaw measurement.
+     */
+    void SetVisionMeasurements(units::radian_t yaw, units::second_t timestamp);
+
+    /**
      * Returns currently set control mode.
      */
     ControlMode GetControlMode() const;
@@ -247,6 +257,9 @@ private:
         m_plant, {0.01245, 0.109726}, {12.0}, Constants::kControllerPeriod};
     frc::LinearPlantInversionFeedforward<2, 1> m_ff{
         m_plant, Constants::kControllerPeriod};
+
+    units::radian_t m_visionYaw;
+    units::second_t m_timestamp;
 
     ControlMode m_controlMode = ControlMode::kManual;
 

--- a/src/main/include/subsystems/Flywheel.hpp
+++ b/src/main/include/subsystems/Flywheel.hpp
@@ -26,6 +26,7 @@
 #include "rev/CANSparkMax.hpp"
 #include "subsystems/ControlledSubsystemBase.hpp"
 #include "subsystems/Flywheel.hpp"
+#include "subsystems/Vision.hpp"
 
 namespace frc3512 {
 
@@ -38,6 +39,13 @@ class Drivetrain;
  */
 class Flywheel : public ControlledSubsystemBase<1, 1, 1> {
 public:
+
+    /**
+     * Producer-consumer queue for global pose measurements from Vision
+     * subsystem.
+     */
+    static_concurrent_queue<Vision::GlobalMeasurement, 8> visionQueue;
+
     /**
      * Constructs a Flywheel.
      *
@@ -95,6 +103,13 @@ public:
     void SetGoalFromPose();
 
     /**
+     * Takes range measurement from vision subsystem. Range measurement is flat distance
+     * from front of target to face of camera. Sets angular velocity goal determined 
+     * by the lookup table.  
+     */
+    void SetGoalFromVision();
+
+    /**
      * Returns true if the flywheel has been set to a nonzero goal.
      */
     bool IsOn() const;
@@ -121,6 +136,13 @@ public:
      */
     units::radians_per_second_t GetReferenceForPose(
         const frc::Pose2d& drivetrainPose) const;
+
+    /**
+     * Returns angular velocity reference that will hit the target at a given
+     * range measurement from vision. 
+     */
+    units::radians_per_second_t GetReferenceForRange(
+        const units::meter_t& range) const;
 
     void DisabledInit() override { Disable(); }
 

--- a/src/main/include/subsystems/Flywheel.hpp
+++ b/src/main/include/subsystems/Flywheel.hpp
@@ -39,7 +39,6 @@ class Drivetrain;
  */
 class Flywheel : public ControlledSubsystemBase<1, 1, 1> {
 public:
-
     /**
      * Producer-consumer queue for global pose measurements from Vision
      * subsystem.
@@ -103,9 +102,9 @@ public:
     void SetGoalFromPose();
 
     /**
-     * Takes range measurement from vision subsystem. Range measurement is flat distance
-     * from front of target to face of camera. Sets angular velocity goal determined 
-     * by the lookup table.  
+     * Takes range measurement from vision subsystem. Range measurement is flat
+     * distance from front of target to face of camera. Sets angular velocity
+     * goal determined by the lookup table.
      */
     void SetGoalFromVision();
 
@@ -139,10 +138,10 @@ public:
 
     /**
      * Returns angular velocity reference that will hit the target at a given
-     * range measurement from vision. 
+     * range measurement from vision.
      */
     units::radians_per_second_t GetReferenceForRange(
-        const units::meter_t& range) const;
+        units::meter_t range) const;
 
     void DisabledInit() override { Disable(); }
 

--- a/src/main/include/subsystems/Turret.hpp
+++ b/src/main/include/subsystems/Turret.hpp
@@ -13,7 +13,6 @@
 #include <frc/simulation/AnalogInputSim.h>
 #include <frc/simulation/DutyCycleEncoderSim.h>
 #include <frc/simulation/LinearSystemSim.h>
-#include <frc2/Timer.h>
 #include <networktables/NetworkTableEntry.h>
 #include <units/angle.h>
 #include <units/current.h>
@@ -157,7 +156,6 @@ public:
     void TeleopInit() override {
         Enable();
         SetControlMode(TurretController::ControlMode::kClosedLoop);
-        // m_limitTimer.Start();
     }
 
     void TeleopPeriodic() override;
@@ -201,8 +199,6 @@ private:
     Flywheel& m_flywheel;
 
     frc::Transform2d cameraInGlobalToDrivetrainInGlobal;
-
-    frc2::Timer m_limitTimer;
 
     // Simulation variables
     frc::sim::LinearSystemSim<2, 1, 1> m_turretSim{m_controller.GetPlant(),

--- a/src/main/include/subsystems/Vision.hpp
+++ b/src/main/include/subsystems/Vision.hpp
@@ -53,6 +53,12 @@ public:
         frc::Pose2d drivetrainInGlobal;
         /// Timestamp at which the measurement was taken
         units::second_t timestamp;
+        /// Yaw reported by photonvision
+        units::radian_t yaw;
+        /// Pitch reported by photonvision
+        units::radian_t pitch;
+        /// Range from robot to target
+        units::meter_t range;
     };
 
     /**
@@ -105,12 +111,21 @@ public:
         const frc::Pose2d& drivetrainPose,
         const frc::Transform2d& turretInGlobalToDrivetrainInGlobal);
 
+    /**
+     * Returns whether or not a vision target is within the camera's field of view. 
+     */
+    bool IsTargetDetected() const;
+
     void SimulationInit() override;
 
     void RobotPeriodic() override;
 
 private:
     photonlib::PhotonCamera m_rpiCam{kCameraName};
+    units::degree_t m_pitch;
+    units::degree_t m_yaw;
+
+    bool m_isTargetDetected = false;
 
     std::mutex m_subsystemQueuesMutex;
 
@@ -123,6 +138,8 @@ private:
         "/Diagnostics/Vision/Turret pose");
     nt::NetworkTableEntry m_yawEntry =
         NetworkTableUtil::MakeDoubleEntry("/Diagnostics/Vision/Yaw");
+    nt::NetworkTableEntry m_rangeEntry =
+        NetworkTableUtil::MakeDoubleEntry("/Diagnostics/Vision/Range Estimate");
 
     // Simulation variables
     photonlib::SimVisionSystem m_simVision{kCameraName,

--- a/src/main/include/subsystems/Vision.hpp
+++ b/src/main/include/subsystems/Vision.hpp
@@ -112,7 +112,8 @@ public:
         const frc::Transform2d& turretInGlobalToDrivetrainInGlobal);
 
     /**
-     * Returns whether or not a vision target is within the camera's field of view. 
+     * Returns whether or not a vision target is within the camera's field of
+     * view.
      */
     bool IsTargetDetected() const;
 


### PR DESCRIPTION
Implement using vision yaw to directly steer the turret. Use vision pitch to find range measurement from camera to target for flywheel speed. 